### PR TITLE
fix errors in Makefile preventing build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ LIB=xmplay.so
 
 all: $(LIB)
 
-%.o: %.c
-	$(CC) -c -o $@ $< $(LIBS) $(FLAGS)
+%.so: %.c
+	$(CC) -o $@ $< $(LIBS) $(FLAGS)
 
 clean:
 	rm $(LIB)


### PR DESCRIPTION
1. -c flag used for object files only, and not for shared libs
2. %.o was instead of %.so, and thus target from $(LIB) wasn't matched
